### PR TITLE
Upgrade rake to version 12.3.3 or later

### DIFF
--- a/cryptocompare.gemspec
+++ b/cryptocompare.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{A Ruby gem for communicating with the CryptoCompare API}
   spec.homepage      = "https://github.com/alexanderdavidpan/cryptocompare"
   spec.license       = "MIT"
-  
+
   spec.required_ruby_version = '>= 2.0.0'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.1.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"


### PR DESCRIPTION
### Purpose

**CVE-2020-8130**
**moderate severity**
**Vulnerable versions**: <= 12.3.2
**Patched version**: 12.3.3

There is an OS command injection vulnerability in Ruby Rake before 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character |.

### Changes

Upgrade rake to version 12.3.3 or later

### Testing

- Test suite passes.