### PR TITLE
Add api_key param mapping

### DIFF
--- a/config/query_param_mapping.yml
+++ b/config/query_param_mapping.yml
@@ -12,3 +12,4 @@ to_syms: tsyms
 to_ts: toTs
 ts: ts
 utc_offset: UTCHourDiff
+api_key: api_key


### PR DESCRIPTION
Right now it's impossible to use `api_key` as a query param. This PR makes this possible