### PR TITLE
Update bundler version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 rvm:
   - 2.3.0
-before_install: gem install bundler -v 2.1.4
+before_install: gem install bundler -v 2.2.31
 addons:
   code_climate:
     repo_token:

--- a/cryptocompare.gemspec
+++ b/cryptocompare.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.1.0"
+  spec.add_development_dependency "bundler", "~> 2.2.0"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "vcr"


### PR DESCRIPTION
# Purpose

To update out-of-date bundler version causing builds to fail. (example: https://travis-ci.org/github/alexanderdavidpan/cryptocompare)

# Changes

Update bundler version

# Testing

Should be covered by continuous integration via TravisCI