### PR TITLE
Add .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
+# See: https://circleci.com/docs/2.0/orb-intro/
+orbs:
+  ruby: circleci/ruby@0.1.2
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.6.3-stretch-node
+    executor: ruby/default
+    steps:
+      - checkout
+      - run:
+          name: Which bundler?
+          command: bundle -v
+      - ruby/bundle-install
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  sample: # This is the name of the workflow, feel free to change it to better match your workflow.
+    # Inside the workflow, you define the jobs you want to run.
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,9 @@ jobs:
       - ruby/install:
           version: '2.7'
       - run: echo "Ruby 2.7 has been installed"
-      - ruby/install-deps
+      - ruby/install-deps:
+          bundler-version: '2.2.31'
+          with-cache: false
       - run:
           command: 'bundle exec rake test'
           name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,22 +5,23 @@ version: 2.1
 # Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
 # See: https://circleci.com/docs/2.0/orb-intro/
 orbs:
-  ruby: circleci/ruby@0.1.2
+  ruby: circleci/ruby@1.2.0
 
 # Define a job to be invoked later in a workflow.
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.6.3-stretch-node
-    executor: ruby/default
+      - image: 'cimg/base:stable'
     steps:
       - checkout
+      - ruby/install:
+          version: '2.7'
+      - run: echo "Ruby 2.7 has been installed"
+      - ruby/install-deps
       - run:
-          name: Which bundler?
-          command: bundle -v
-      - ruby/bundle-install
-
+          command: 'bundle exec rake test'
+          name: Run Tests
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,71 @@
+PATH
+  remote: .
+  specs:
+    cryptocompare (0.15.0)
+      faraday
+      json
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    codeclimate-test-reporter (1.0.9)
+      simplecov (<= 0.13)
+    crack (0.4.5)
+      rexml
+    docile (1.1.5)
+    faraday (1.8.0)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    hashdiff (1.0.1)
+    json (2.6.1)
+    minitest (5.14.4)
+    multipart-post (2.1.1)
+    public_suffix (4.0.6)
+    rake (13.0.6)
+    rexml (3.2.5)
+    ruby2_keywords (0.0.5)
+    simplecov (0.13.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    vcr (6.0.0)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+
+PLATFORMS
+  x86_64-darwin-19
+  x86_64-linux
+
+DEPENDENCIES
+  bundler (~> 2.2.0)
+  codeclimate-test-reporter (~> 1.0.0)
+  cryptocompare!
+  minitest (~> 5.0)
+  rake (>= 12.3.3)
+  simplecov
+  vcr
+  webmock
+
+BUNDLED WITH
+   2.2.31

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cryptocompare
 
-[![Gem Version](https://badge.fury.io/rb/cryptocompare.svg)](http://badge.fury.io/rb/cryptocompare) [![Build Status](https://travis-ci.org/alexanderdavidpan/cryptocompare.svg)](https://travis-ci.org/alexanderdavidpan/cryptocompare)
+[![Gem Version](https://badge.fury.io/rb/cryptocompare.svg)](http://badge.fury.io/rb/cryptocompare) [![CircleCI](https://circleci.com/gh/alexanderdavidpan/cryptocompare.svg?style=svg)](https://circleci.com/gh/alexanderdavidpan/cryptocompare)
 [![Test Coverage](https://codeclimate.com/github/alexanderdavidpan/cryptocompare/badges/coverage.svg)](https://codeclimate.com/github/alexanderdavidpan/cryptocompare/coverage)
 
 This is a Ruby gem that utilizes the CryptoCompare API to fetch data related to cryptocurrencies.

--- a/cryptocompare.gemspec
+++ b/cryptocompare.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.1.0"
+  spec.add_development_dependency "bundler", "~> 2.2.0"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "vcr"


### PR DESCRIPTION
# Purpose

TravisCI no longer supports free builds for open-source projects, so moving this project over to use CircleCI, which will support a limited number of builds per month.

# Changes
- Add .circleci/config.yml

# Testing
- Should be tested using CircleCI
