### PR TITLE
(feature) Add api_key query param to query param mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,6 +930,15 @@ Cryptocompare::Exchanges.all
 
 If no exchange option is specified, then the default 'CCCAGG' is used. This is cryptocompare's aggregated data.
 
+### API Keys
+
+Some requests will require an API key. In order to obtain an API key, you will need to request one from Cryptocompare. You can then pass it in as an optional parameter in the any Cryptocompare module method like so:
+
+```ruby
+Cryptocompare::Price.find('ETH', 'USD', { api_key: 'API_KEY' })
+# => {"ETH"=>{"USD"=>4714.16}}
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/config/query_param_mapping.yml
+++ b/config/query_param_mapping.yml
@@ -12,3 +12,4 @@ to_syms: tsyms
 to_ts: toTs
 ts: ts
 utc_offset: UTCHourDiff
+api_key: api_key

--- a/test/test_query_param_helper.rb
+++ b/test/test_query_param_helper.rb
@@ -7,6 +7,7 @@ class TestQueryParamHelper < Minitest::Test
     params = {
       'agg'       => 10,
       'all_data'  => true,
+      'api_key'   => 'API_KEY'
       'e'         => 'COINBASE',
       'from_sym'  => 'BTC',
       'from_syms' => 'BTC,ETH',
@@ -19,7 +20,7 @@ class TestQueryParamHelper < Minitest::Test
     }
 
     expected_path = "https://min-api.cryptocompare.com?aggregate=10" \
-    "&allData=true&e=COINBASE&fsym=BTC&fsyms=BTC,ETH&limit=10&toTs=1452680400" \
+    "&allData=true&api_key=API_KEY&e=COINBASE&fsym=BTC&fsyms=BTC,ETH&limit=10&toTs=1452680400" \
     "&tryConversion=false&ts=1452680400&tsym=USD&tsyms=USD,EUR"
 
     assert_equal expected_path, Cryptocompare::QueryParamHelper.set_query_params(api_url, params)

--- a/test/test_query_param_helper.rb
+++ b/test/test_query_param_helper.rb
@@ -7,7 +7,7 @@ class TestQueryParamHelper < Minitest::Test
     params = {
       'agg'       => 10,
       'all_data'  => true,
-      'api_key'   => 'API_KEY'
+      'api_key'   => 'API_KEY',
       'e'         => 'COINBASE',
       'from_sym'  => 'BTC',
       'from_syms' => 'BTC,ETH',


### PR DESCRIPTION
# Purpose

Certain Cryptocompare API endpoints require an API key. There have been requests to add this as an optional parameter to requests: https://github.com/alexanderdavidpan/cryptocompare/issues/12

There have also been PRs that have been stale, so I am adding the code, testing, and updated documentation here.

# Changes

- Add `api_key` query param to query param mapping
- Update unit test
- Update documentation

# Testing

- Tested locally to check that API url was constructed correctly with api_key query param. Also validated via unit test.