### PR TITLE
(feature) Create Cryptocompare::Stats module

### DIFF
--- a/README.md
+++ b/README.md
@@ -984,6 +984,41 @@ Cryptocompare::Exchanges.all
 
 If no exchange option is specified, then the default 'CCCAGG' is used. This is cryptocompare's aggregated data.
 
+### Stats
+
+Get stats such as rate limit.
+
+**Examples:**
+
+Find out how many calls you have left in the current month, day, hour, minute and second.
+
+```ruby
+Cryptocompare::Stats.rate_limit
+# => {
+#   "Response" => "Success",
+#   "Message" => "",
+#   "HasWarning" => false,
+#   "Type" => 100,
+#   "RateLimit" => {},
+#   "Data" => {
+#     "calls_made" => {
+#       "second" => 1,
+#       "minute" => 2,
+#       "hour" => 2,
+#       "day" => 2,
+#       "month" => 33
+#     },
+#     "calls_left" => {
+#       "second" => 19,
+#       "minute" => 298,
+#       "hour" => 2998,
+#       "day" => 7498,
+#       "month" => 49967
+#     }
+#   }
+# }
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/cryptocompare.rb
+++ b/lib/cryptocompare.rb
@@ -10,6 +10,7 @@ require_relative "cryptocompare/price"
 require_relative "cryptocompare/price_historical"
 require_relative "cryptocompare/helpers/query_param_helper"
 require_relative "cryptocompare/top_pairs"
+require_relative "cryptocompare/stats"
 
 module Cryptocompare
 end

--- a/lib/cryptocompare/stats.rb
+++ b/lib/cryptocompare/stats.rb
@@ -3,8 +3,8 @@ require 'json'
 
 module Cryptocompare
   module Stats
-    API_URL = 'https://min-api.cryptocompare.com/stats/rate/limit'.freeze
-    private_constant :API_URL
+    RATE_LIMIT_API_URL = 'https://min-api.cryptocompare.com/stats/rate/limit'.freeze
+    private_constant :RATE_LIMIT_API_URL
 
     # Find out how many calls you have left in the current month, day, hour, minute and second
     #
@@ -44,7 +44,7 @@ module Cryptocompare
     #   }
     # }
     def self.rate_limit
-      api_resp = Faraday.get(API_URL)
+      api_resp = Faraday.get(RATE_LIMIT_API_URL)
       JSON.parse(api_resp.body)
     end
   end

--- a/lib/cryptocompare/stats.rb
+++ b/lib/cryptocompare/stats.rb
@@ -20,7 +20,29 @@ module Cryptocompare
     #
     # Sample response
     #
-    # TODO
+    # {
+    #   "Response" => "Success",
+    #   "Message" => "",
+    #   "HasWarning" => false,
+    #   "Type" => 100,
+    #   "RateLimit" => {},
+    #   "Data" => {
+    #     "calls_made" => {
+    #       "second" => 1,
+    #       "minute" => 2,
+    #       "hour" => 2,
+    #       "day" => 2,
+    #       "month" => 33
+    #     },
+    #     "calls_left" => {
+    #       "second" => 19,
+    #       "minute" => 298,
+    #       "hour" => 2998,
+    #       "day" => 7498,
+    #       "month" => 49967
+    #     }
+    #   }
+    # }
     def self.rate_limit
       api_resp = Faraday.get(API_URL)
       JSON.parse(api_resp.body)

--- a/lib/cryptocompare/stats.rb
+++ b/lib/cryptocompare/stats.rb
@@ -1,0 +1,29 @@
+require 'faraday'
+require 'json'
+
+module Cryptocompare
+  module Stats
+    API_URL = 'https://min-api.cryptocompare.com/stats/rate/limit'.freeze
+    private_constant :API_URL
+
+    # Find out how many calls you have left in the current month, day, hour, minute and second
+    #
+    # ==== Returns
+    #
+    # [Hash] Returns a hash containing data about calls_made and calls_left
+    #
+    # ==== Examples
+    #
+    # Find out how calls you have made and have left in the current month, day, hour, minute and second
+    #
+    #   Cryptocompare::Stats.rate_limit
+    #
+    # Sample response
+    #
+    # TODO
+    def self.rate_limit
+      api_resp = Faraday.get(API_URL)
+      JSON.parse(api_resp.body)
+    end
+  end
+end

--- a/test/fixtures/rate_limit.yml
+++ b/test/fixtures/rate_limit.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://min-api.cryptocompare.com/stats/rate/limit
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.8.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Thu, 25 Nov 2021 06:45:13 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Content-Security-Policy:
+      - frame-ancestors 'none'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET, POST, OPTIONS
+      Access-Control-Allow-Headers:
+      - Content-Type, Cookie, Set-Cookie, Authorization
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Cache-Control:
+      - no-cache, no-store
+      X-Cryptocompare-Cache-Hit:
+      - 'false'
+      X-Cryptocompare-Server-Id:
+      - ccc-api41
+    body:
+      encoding: ASCII-8BIT
+      string: '{"Response":"Success","Message":"","HasWarning":false,"Type":100,"RateLimit":{},"Data":{"calls_made":{"second":1,"minute":1,"hour":7,"day":7,"month":38},"calls_left":{"second":19,"minute":299,"hour":2993,"day":7493,"month":49962}}}'
+  recorded_at: Thu, 25 Nov 2021 06:45:13 GMT
+recorded_with: VCR 6.0.0

--- a/test/test_stats.rb
+++ b/test/test_stats.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+class TestStats < Minitest::Test
+  RATE_LIMIT_KEYS = %w[
+    Response
+    Message
+    HasWarning
+    Type
+    RateLimit
+    Data
+  ].freeze
+
+  RATE_LIMIT_DATA_KEYS = %w[
+    calls_made
+    calls_left
+  ].freeze
+
+  RATE_LIMIT_METADATA_KEYS = %w[
+    second
+    minute
+    hour
+    day
+    month
+  ].freeze
+
+  def test_rate_limit
+    VCR.use_cassette('rate_limit') do
+      rate_limit_resp = Cryptocompare::Stats.rate_limit
+      assert_equal 'Success', rate_limit_resp['Response']
+      assert rate_limit_resp.kind_of?(Hash)
+
+      rate_limit_resp.each do |rate_limit_key, _|
+        assert RATE_LIMIT_KEYS.include?(rate_limit_key)
+      end
+
+      rate_limit_resp_data = rate_limit_resp.fetch('Data')
+      rate_limit_resp_data.each do |rate_limit_data_key, _|
+        assert RATE_LIMIT_DATA_KEYS.include?(rate_limit_data_key)
+      end
+
+      calls_made_data = rate_limit_resp_data.fetch('calls_made')
+      calls_made_data.each do |calls_made_key, calls_made_value|
+        assert RATE_LIMIT_METADATA_KEYS.include?(calls_made_key)
+        assert calls_made_value.kind_of?(Integer)
+      end
+
+      calls_left_data = rate_limit_resp_data.fetch('calls_left')
+      calls_left_data.each do |calls_left_key, calls_left_value|
+        assert RATE_LIMIT_METADATA_KEYS.include?(calls_left_key)
+        assert calls_left_value.kind_of?(Integer)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Purpose

To add a method to gain visibility into rate limits

### Changes
- Add rate_limit class method
- Add documentation
- Add unit test
- Add VCR fixture

### Test

- Add unit test
- Add VCR fixture
- Tested locally using local gem build and running `Cryptocompare::Stats.rate_limit`

### Caveat

I did not implement the rate limit hour endpoint [documented here](https://min-api.cryptocompare.com/documentation?key=Other&cat=rateLimitHourEndpoint&api_key=test) because the message returned is:
> "Warning: This endpoint will be deprecated shortly, please instead use /stats/rate/limit to obtain current rate limit information."

Also we have this information in the `Cryptocompare::Stats.rate_limit` call already.